### PR TITLE
Add Environment Variable support

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,10 @@ import (
 )
 
 func main() {
-	err := SQLConnect()
+	sqlserver, sqluser, sqlpass, sqldb := getCreds()
+	log.Printf("DB Connection: Server=%s User=%s DB=%s", sqlserver, sqluser, sqldb)
+
+	err := SQLConnect(sqlserver, sqluser, sqlpass, sqldb)
 	if err != nil {
 		log.Printf("DB ERROR: %s", err.Error())
 		return
@@ -40,6 +43,22 @@ func main() {
 	close(ch)
 
 	server.Stop()
+}
+
+func getEnvVar(key, fallback string) string {
+    value, exists := os.LookupEnv(key)
+    if !exists {
+        value = fallback
+    }
+    return value
+}
+
+func getCreds() (string, string, string, string){
+	sqlserver := getEnvVar("FREEPBX_SQLSERVER", "127.0.0.1:3306")
+	sqluser := getEnvVar("FREEPBX_SQLUSER", "root")
+	sqlpass := getEnvVar("FREEPBX_SQLPASS", "")
+	sqldb := getEnvVar("FREEPBX_SQLDB", "asterisk")
+	return sqlserver, sqluser, sqlpass, sqldb
 }
 
 func handleBind(w ldap.ResponseWriter, m *ldap.Message) {

--- a/sql.go
+++ b/sql.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"strings"
-
 	"database/sql"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -11,14 +10,9 @@ import (
 
 var (
 	dbConn *sql.DB
-
-	sqlserver string = "127.0.0.1:3306"
-	sqluser   string = "root"
-	sqlpass   string = ""
-	sqldb     string = "asterisk"
 )
 
-func SQLConnect() (err error) {
+func SQLConnect(sqlserver string, sqluser string, sqlpass string, sqldb string) (err error)  {
 	if strings.ContainsRune(sqlserver, ':') {
 		dbConn, err = sql.Open("mysql", sqluser+":"+sqlpass+"@tcp("+sqlserver+")/"+sqldb)
 	} else {


### PR DESCRIPTION
An attempt to add support for EnvVars as raised in #4 

If Environment Variables aren't set it will revert back to using the defaults that were previously hardcoded.

Example Variables:

FREEPBX_SQLSERVER="10.1.42.12:3306"
FREEPBX_SQLUSER="asterisk"
FREEPBX_SQLPASS="hunter2"
FREEPBX_SQLDB="asterisk"

This is my first time using Go but I think I've followed your existing structure and style so hopefully it's ok.

Thanks