### PR TITLE
Fix first SQL connection

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -24,7 +24,7 @@ func SQLConnect() (err error) {
 	} else {
 		dbConn, err = sql.Open("mysql", sqluser+":"+sqlpass+"@tcp("+sqlserver+":3306)/"+sqldb)
 	}
-	if err != nil {
+	if err == nil {
 		err = dbConn.Ping()
 	}
 	return


### PR DESCRIPTION
sql.Open() doesn't actually attempt to open the Database, it only creates the object [More info](https://github.com/golang/go/issues/4804) which means if credentials are wrong it will only fail the first time it tries to connect, i.e a phone queries the LDAP directory.

It looks like there is a small bug when calling sql.Ping() which should fail if it cannot connect immediately rather than waiting for an actual query.

Fix for #6

