### PR TITLE
Allow search without AND or OR

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,6 +168,10 @@ func handleSearchDSE(w ldap.ResponseWriter, m *ldap.Message) {
 					where += ret
 				}
 			}
+		case message.FilterSubstrings:
+			if ret := filterProcessSub(val); ret != "" {
+				where += ret
+			}
 		default:
 			log.Printf("Searching without filter...")
 		}


### PR DESCRIPTION
A user reported issues when searching without AND or OR, e.g just `telephoneNumber=%` 

This PR resolves the issue